### PR TITLE
feat: make images zoomable

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "date-fns": "^4.1.0",
     "katex": "^0.16.21",
     "mdast-util-to-string": "^4.0.0",
+    "medium-zoom": "^1.1.0",
     "pnpm": "^10.2.1",
     "reading-time": "^1.5.0",
     "rehype-katex": "^7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       mdast-util-to-string:
         specifier: ^4.0.0
         version: 4.0.0
+      medium-zoom:
+        specifier: ^1.1.0
+        version: 1.1.0
       pnpm:
         specifier: ^10.2.1
         version: 10.2.1
@@ -1507,6 +1510,9 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
+  medium-zoom@1.1.0:
+    resolution: {integrity: sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==}
 
   micromark-core-commonmark@2.0.2:
     resolution: {integrity: sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==}
@@ -3985,6 +3991,8 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.12.2: {}
+
+  medium-zoom@1.1.0: {}
 
   micromark-core-commonmark@2.0.2:
     dependencies:

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -21,5 +21,16 @@ const { title, description, image } = Astro.props;
     <main>
       <slot />
     </main>
+    <script>
+      const imageSelectors = [
+        ...document.querySelectorAll('article.prose img'),
+        ...document.querySelectorAll('[data-zoomable]'),
+      ] as HTMLElement[];
+
+      import mediumZoom from "medium-zoom";
+      mediumZoom(imageSelectors, {
+        background: "var(--color-zinc-950)",
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
I really enjoy your website. It's well made and awesome to look at.

The only thing that bothered be was that the images in blogs are not zoomable and the content is sometimes very small, so it's had to read.
Therefore, I changed it and give you the option to also include the changes (because you also mentioned that you are open to contibutions).

I use [`medium-zoom`](https://github.com/francoischalifour/medium-zoom) because I think it has the cleanest zoom of images and is really easy to integrate. This of course gives you a little bit more JS, but I think it's worth it in this case.
I made it so that per default all blog images can be zoomed and you can also give any other image on the site the `data-zoomable` attribute so that it is zoomable as well.

Feel free to ask me to change anything or change whatever you want yourself 💜 

Thank you for your website, it is very inspiring!